### PR TITLE
[Cursor] Replace execute_python with general execute_command function

### DIFF
--- a/tool_definitions.py
+++ b/tool_definitions.py
@@ -63,48 +63,21 @@ function_definitions = [
         }
     },
     {
-        "name": "execute_python",
-        "description": "Execute a Python script and return its stdout. The script should already exist, e.g. it was created by the create_file tool.",
+        "name": "execute_command",
+        "description": "Execute a terminal command and return its output.",
         "parameters": {
             "type": "object",
             "properties": {
-                "filename": {
+                "command": {
                     "type": "string",
-                    "description": "Name of the Python file to execute"
-                }
-            },
-            "required": ["filename"]
-        }
-    },
-    {
-        "name": "install_python_package",
-        "description": "Install Python packages using pip. Can specify version requirements.",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "packages": {
-                    "oneOf": [
-                        {
-                            "type": "string",
-                            "description": "Single package name with optional version specifier (e.g. 'pandas>=2.0.0')"
-                        },
-                        {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            },
-                            "description": "List of package names with optional version specifiers"
-                        }
-                    ],
-                    "description": "Package(s) to install"
+                    "description": "The terminal command to execute"
                 },
-                "upgrade": {
-                    "type": "boolean",
-                    "description": "Whether to upgrade the package if it's already installed",
-                    "default": False
+                "explanation": {
+                    "type": "string",
+                    "description": "Explanation of what the command does"
                 }
             },
-            "required": ["packages"]
+            "required": ["command", "explanation"]
         }
     }
 ] 


### PR DESCRIPTION

This PR replaces the specific execute_python and install_python_package functions with a more general execute_command function that can handle any terminal command. This change makes the system more flexible and reduces code duplication.

Changes:
- Remove execute_python and install_python_package functions
- Add new execute_command function for general terminal command execution
- Update function handling in deep_research_agent.py
- Improve command execution with better output handling